### PR TITLE
Add DigiByte (DGB)

### DIFF
--- a/slips/slip-0044.rst
+++ b/slips/slip-0044.rst
@@ -49,6 +49,7 @@ index hexa       coin
 13    0x8000000d Mazacoin
 14    0x8000000e Viacoin
 15    0x8000000f ClearingHouse
+16    0x80000010 DigiByte
 ===== ========== ================================
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.


### PR DESCRIPTION
We've added a chainkey module for Encompass, our multicoin electrum fork https://github.com/mazaclub/encompass to support Digibyte - production release will follow registered chain within 10days.