### PR TITLE
Add the Open Assets coin type

### DIFF
--- a/slips/slip-0044.rst
+++ b/slips/slip-0044.rst
@@ -54,6 +54,7 @@ index hexa       coin
 18    0x80000012 Digitalcoin
 19    0x80000013 Cannacoin
 20    0x80000014 DigiByte
+21    0x80000015 `Open Assets <https://github.com/OpenAssets/open-assets-protocol>`_
 ===== ========== ================================
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.


### PR DESCRIPTION
The Open Assets coin type is used on Coinprism.