### PR TITLE
Add Clam Chain Index

### DIFF
--- a/slips/slip-0044.rst
+++ b/slips/slip-0044.rst
@@ -55,7 +55,7 @@ index hexa       coin
 19    0x80000013 Cannacoin
 20    0x80000014 DigiByte
 21    0x80000015 `Open Assets <https://github.com/OpenAssets/open-assets-protocol>`_
-22    0x80000016 Clam
+23    0x80000016 Clam
 ===== ========== ================================
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.

--- a/slips/slip-0044.rst
+++ b/slips/slip-0044.rst
@@ -55,6 +55,7 @@ index hexa       coin
 19    0x80000013 Cannacoin
 20    0x80000014 DigiByte
 21    0x80000015 `Open Assets <https://github.com/OpenAssets/open-assets-protocol>`_
+22    0x80000016 Clam
 ===== ========== ================================
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.


### PR DESCRIPTION
We're about to add Clam to [Encompass](https://github.com/mazaclub/encompass), so it needs a BIP-0044 index.