### PR TITLE
Add Open Chain to SLIP 44

### DIFF
--- a/slips/slip-0044.rst
+++ b/slips/slip-0044.rst
@@ -70,6 +70,7 @@ index hexa       coin
 34    0x80000022 `Canada eCoin <https://github.com/Canada-eCoin/>`_
 35    0x80000023 ShadowCash
 50    0x80000032 `Novacoin <https://github.com/novacoin-project/novacoin>`_
+64    0x80000040 `Open Chain <https://github.com/openchain/>`_
 77    0x8000004d `DogecoinDark <https://github.com/doged/>`_
 ===== ========== ================================
 


### PR DESCRIPTION
Adding a number for Open Chain as we will need this for the launch. We have a wallet currently in private Beta.