### PR TITLE
Add ClubCoin to the BIP44 registry.

### DIFF
--- a/slips/slip-0044.rst
+++ b/slips/slip-0044.rst
@@ -84,6 +84,7 @@ index hexa       coin
 69    0x80000045 `OKCash <https://github.com/okcashpro/>`_
 77    0x8000004d `DogecoinDark <https://github.com/doged/>`_
 78    0x8000004e `Electronic Gulden <https://egulden.org/>`_
+79    0x8000004f `ClubCoin <https://clubcoin.co/>`_
 ===== ========== ================================
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.


### PR DESCRIPTION
Us folks at ClubCoin are actively working on bringing BIP-0044 support to the coin. We would like to reserve this coin type for ClubCoin.