### PR TITLE
Replace trezord links with the link to the current one

### DIFF
--- a/trezor-tech/api.rst
+++ b/trezor-tech/api.rst
@@ -58,7 +58,7 @@ trezord is not intended for direct use by developers - it is still a little low-
 
 However, the *end user* of the web app needs to install either trezord or Chrome Extension.
 
-`See more documentation on the github page <https://github.com/trezor/trezord>`_.
+`See more documentation on the github page <https://github.com/trezor/trezord-go>`_.
 
 
 trezor-android

--- a/trezor-tech/resources.rst
+++ b/trezor-tech/resources.rst
@@ -16,7 +16,7 @@ Git repositories
 
   * `trezor-emu <https://github.com/trezor/trezor-emu>`_ -- Emulator
 
-  * `trezord <https://github.com/trezor/trezord>`_ -- Communication Daemon (aka Bridge)
+  * `trezord <https://github.com/trezor/trezord-go>`_ -- Communication Daemon (aka Bridge)
 
   * `trezor.js <https://github.com/trezor/trezor.js>`_ -- Javascript Client Library
 


### PR DESCRIPTION
was pointing to the obsolete one before